### PR TITLE
use memcpy in sph_dec* to avoid breaking compiler strict aliasing rules that could cause optimization to go awry, reset structure memory on init

### DIFF
--- a/c/bmw.c
+++ b/c/bmw.c
@@ -609,6 +609,7 @@ static const sph_u32 final_s[16] = {
 static void
 bmw32_init(sph_bmw_small_context *sc, const sph_u32 *iv)
 {
+	memset(sc, 0, sizeof(sph_bmw_small_context));
 	memcpy(sc->H, iv, sizeof sc->H);
 	sc->ptr = 0;
 #if SPH_64
@@ -759,6 +760,7 @@ static const sph_u64 final_b[16] = {
 static void
 bmw64_init(sph_bmw_big_context *sc, const sph_u64 *iv)
 {
+	memset(sc, 0, sizeof(sph_bmw_big_context));
 	memcpy(sc->H, iv, sizeof sc->H);
 	sc->ptr = 0;
 	sc->bit_count = 0;

--- a/c/sph_types.h
+++ b/c/sph_types.h
@@ -1427,9 +1427,13 @@ sph_dec32be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #else
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
@@ -1464,9 +1468,13 @@ static SPH_INLINE sph_u32
 sph_dec32be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #else
 	return ((sph_u32)(((const unsigned char *)src)[0]) << 24)
 		| ((sph_u32)(((const unsigned char *)src)[1]) << 16)
@@ -1545,9 +1553,13 @@ sph_dec32le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #else
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
@@ -1615,7 +1627,9 @@ static SPH_INLINE sph_u32
 sph_dec32le_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #elif SPH_BIG_ENDIAN
 #if SPH_SPARCV9_GCC && !SPH_NO_ASM
 	sph_u32 tmp;
@@ -1632,7 +1646,9 @@ sph_dec32le_aligned(const void *src)
 	return tmp;
  */
 #else
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #endif
 #else
 	return (sph_u32)(((const unsigned char *)src)[0])
@@ -1726,9 +1742,13 @@ sph_dec64be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return sph_bswap64(tmp);
 #else
-	return *(const sph_u64 *)src;
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {
@@ -1771,9 +1791,13 @@ static SPH_INLINE sph_u64
 sph_dec64be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return sph_bswap64(tmp);
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u64 *)src;
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return tmp;
 #else
 	return ((sph_u64)(((const unsigned char *)src)[0]) << 56)
 		| ((sph_u64)(((const unsigned char *)src)[1]) << 48)
@@ -1868,9 +1892,13 @@ sph_dec64le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return sph_bswap64(tmp);
 #else
-	return *(const sph_u64 *)src;
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {


### PR DESCRIPTION
A couple changes that solves a bug initially found in monacoin.

Gcc will apply some optimizations that include re-ordering memory reads. In some cases when functions are inlined, gcc may shuffle the contents of the various functions around, and make assumptions such as that different types of pointers will not point to the same memory.

There are various ways to solve this, however memcpy will be replaced by a builtin function that, with its length fixed at compile time, will be optimized just fine. A lot of the `sph_dec*` functions could probably be simplified further by relying on memcpy, however I didn't want to alter the original code in any way that would make the actual fix harder to understand.

See the original bug: https://github.com/monacoinproject/monacoin/issues/121
Monacoin merge request: https://github.com/monacoinproject/monacoin/pull/122

Fixes https://github.com/aidansteele/sphlib/issues/1